### PR TITLE
Revert "Use official release of columnation"

### DIFF
--- a/container/Cargo.toml
+++ b/container/Cargo.toml
@@ -6,5 +6,5 @@ description = "Container abstractions for Timely"
 license = "MIT"
 
 [dependencies]
-columnation = { version = "0.1" }
+columnation = { git = "https://github.com/frankmcsherry/columnation" }
 serde = { version = "1.0"}


### PR DESCRIPTION
This reverts commit d5614b78adac5b6b9d7d707396000acbac2478d5.

The reason for the revert is to keep this repo buildable, so that we can use tools like `rust-analyzer` to jump around it. We can then override this dependency in Materialize.